### PR TITLE
set cmake runtime common output runtime directory to ${OUT_DIR}, whic…

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ function (discover_tests DIR)
     endforeach()
 endfunction()
 
+set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${OUT_DIR})
 
 MACRO(SUBDIRLIST result curdir)
 FILE(GLOB children ${curdir}/*) # 


### PR DESCRIPTION
set runtime output directory for binaries to ${OUT_DIR}. This matches our own cuda dll deployment target dir.