### PR TITLE
Changed Point and Size to be template structs and created fk::Rect

### DIFF
--- a/include/fused_kernel/core/data/point.h
+++ b/include/fused_kernel/core/data/point.h
@@ -17,10 +17,14 @@
 #include <fused_kernel/core/utils/utils.h>
 
 namespace fk {
-    struct Point {
-        uint x;
-        uint y;
-        uint z;
-        FK_HOST_DEVICE_CNST Point(const uint x_ = 0, const uint y_ = 0, const uint z_ = 0) : x(x_), y(y_), z(z_) {}
+
+    template <typename T>
+    struct Point_ {
+        T x;
+        T y;
+        T z;
+        FK_HOST_DEVICE_CNST Point_(const T x_ = 0, const T y_ = 0, const T z_ = 0) : x(x_), y(y_), z(z_) {}
     };
+
+    using Point = Point_<uint>;
 } // namespace fk

--- a/include/fused_kernel/core/data/rect.h
+++ b/include/fused_kernel/core/data/rect.h
@@ -1,0 +1,31 @@
+/* Copyright 2024 Oscar Amoros Huguet
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http ://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <fused_kernel/core/data/size.h>
+#include <fused_kernel/core/data/point.h>
+
+namespace fk {
+
+    template <typename P, typename S=P>
+    struct Rect_ {
+        P x{ 0 }, y{0};
+        S width{ 0 }, height{0};
+        constexpr Rect_(const Point& point, const Size& size) : x(point.x), y(point.y), width(size.width), height(size.height) {}
+        constexpr Rect_(const P& x_, const P& y_, const S& width_, const S& height_) : x(x_), y(y_), width(width_), height(height_) {}
+        constexpr Rect_(){}
+    };
+
+    using Rect = Rect_<uint, int>;
+
+} // namespace fk

--- a/include/fused_kernel/core/data/size.h
+++ b/include/fused_kernel/core/data/size.h
@@ -17,11 +17,14 @@
 #include <fused_kernel/core/utils/utils.h>
 
 namespace fk {
-    struct Size {
-        constexpr Size(int width_, int height_) : width(width_),
+    template <typename T>
+    struct Size_ {
+        constexpr Size_(T width_, T height_) : width(width_),
             height(height_) {};
-        Size() {};
-        int width{ 0 };
-        int height{ 0 };
+        constexpr Size_() {};
+        T width{ 0 };
+        T height{ 0 };
     };
+
+    using Size = Size_<int>;
 } // namespace fk

--- a/tests/fused_kernel_library/test_rect.cu
+++ b/tests/fused_kernel_library/test_rect.cu
@@ -1,0 +1,40 @@
+/* Copyright 2024 Oscar Amoros Huguet
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include "tests/main.h"
+
+#include <fused_kernel/core/data/rect.h>
+
+int launch() {
+
+    constexpr fk::Rect test(fk::Point(16, 32), fk::Size(32, 64));
+    static_assert(test.x == 16, "Something wrong");
+    static_assert(test.y == 32, "Something wrong");
+    static_assert(test.width == 32, "Something wrong");
+    static_assert(test.height == 64, "Something wrong");
+
+    constexpr fk::Rect test2;
+    static_assert(test2.x == 0, "Something wrong");
+    static_assert(test2.y == 0, "Something wrong");
+    static_assert(test2.width == 0, "Something wrong");
+    static_assert(test2.height == 0, "Something wrong");
+
+    constexpr fk::Rect_<float, double> test3(3.f, 5.f, 10.0, 20.0);
+    static_assert(test3.x == 3.f, "Something wrong");
+    static_assert(test3.y == 5.f, "Something wrong");
+    static_assert(test3.width == 10.0, "Something wrong");
+    static_assert(test3.height == 20.0, "Something wrong");
+
+    return 0;
+}


### PR DESCRIPTION
Making fk::Point and fk::Size more OpenCV-like, by adding template types, and created fk::Rect, a la OpenCV style.