### PR TITLE
added TEMPLATE_DEPTH for overriding default template depth with nvcc …

### DIFF
--- a/cmake/cmake_init.cmake
+++ b/cmake/cmake_init.cmake
@@ -19,8 +19,10 @@ set(CMAKE_CONFIGURATION_TYPES "Debug;Release;RelWithDebInfo" CACHE STRING "" FOR
 # valid configuration in CMAKE_CONFIGURATION_TYPES. By default this is the debug configuration which is wrong. See:
 # https://gitlab.kitware.com/cmake/cmake/-/issues/20319
 set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO "RelWithDebInfo;Release;")
-
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install")
+
+set (TEMPLATE_DEPTH "default" CACHE STRING  "template depth")
+
 
 cmake_policy(SET CMP0111 NEW) # ensure all targets provide shared libs location
 

--- a/cmake/libs/cuda/target_generation.cmake
+++ b/cmake/libs/cuda/target_generation.cmake
@@ -1,4 +1,3 @@
- 
 function(set_default_cuda_target_properties TARGET_NAME)
     if (WIN32)
         list(APPEND COMPILER_CUDA_FLAGS -Xcompiler=/bigobj)
@@ -20,5 +19,18 @@ function(set_default_cuda_target_properties TARGET_NAME)
     #cuda 12 can compile in parallel, so let's use this 
     if (${CUDA_VERSION_MAJOR} GREATER_EQUAL 12)
         target_compile_options(${TARGET_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-split-compile=0>)
+    endif()
+    
+    if (NOT(${TEMPLATE_DEPTH} STREQUAL  "default"))
+    #bugfix for windows compilation of tests with more than 200 recursions
+    #set it in device code and host
+        target_compile_options(${TARGET_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-ftemplate-depth=${TEMPLATE_DEPTH}>)
+
+        if (WIN32)
+       #cannot be set, no compiler flag available
+        else() 
+        #asume clang or gcc on linux
+        target_compile_options(${TARGET_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-ftemplate-depth=${TEMPLATE_DEPTH}>)           
+        endif()
     endif()
 endfunction()


### PR DESCRIPTION
…. On windows, some tets will fail to build after 200 instantiations. Raising this limit via a compiler flag let us build them.
MSVC does not have  a flag for setting this for host code, so this only applies to device code (nvcc) on windows.
to set this value in cmake-gui, just override TEMPLATE_DEPTH with the desired value (f.i, 300)
![image](https://github.com/user-attachments/assets/60a151d5-eeda-4e06-9e34-e5451040384a)

if no value is set in cmake-gui , then the compiler flag is not added
For command line, override via -DTEMPLATE_DEPTH=<value>
